### PR TITLE
Simplify, fix and clean up the spec file and related files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY:	rpm clean
 
 VERSION ?= 3.4.9
-BUILD_NUMBER ?= 1
+RELEASE ?= 1
 SOURCE = zookeeper-$(VERSION).tar.gz
 TOPDIR = /tmp/zookeeper-rpm
 PWD = $(shell pwd)
@@ -13,7 +13,7 @@ rpm: $(SOURCE)
 			--define "_rpmdir $(PWD)" \
 			--define "_topdir $(TOPDIR)" \
 			--define "version $(VERSION)" \
-			--define "build_number $(BUILD_NUMBER)" \
+			--define "release $(RELEASE)" \
 			zookeeper.spec
 
 source: $(SOURCE)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY:	rpm clean
 
 VERSION ?= 3.4.9
-RELEASE ?= 1
+RELEASE ?= 2
 SOURCE = zookeeper-$(VERSION).tar.gz
 TOPDIR = /tmp/zookeeper-rpm
 PWD = $(shell pwd)
@@ -12,8 +12,8 @@ rpm: $(SOURCE)
 			--define "_sourcedir $(PWD)" \
 			--define "_rpmdir $(PWD)" \
 			--define "_topdir $(TOPDIR)" \
-			--define "version $(VERSION)" \
-			--define "release $(RELEASE)" \
+			--define "zk_version $(VERSION)" \
+			--define "zk_release $(RELEASE)" \
 			zookeeper.spec
 
 source: $(SOURCE)

--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ Building
 --------
     make rpm
 
-Resulting RPM will be avaliable at $(shell pwd)/x86_64
+Resulting RPM will be avaliable at $(shell pwd)/noarch/
 
 Installing and operating
 ------------------------
     sudo yum install zookeeper*.rpm
-    sudo systemctl start zookeeper
     sudo systemctl enable zookeeper
+    sudo systemctl start zookeeper
 
-Zookeeper shell is available via /usr/local/bin/zkcli or just zkcli since /usr/local/bin is usually in the $PATH.
+Zookeeper shell is available via zkcli.
 
 Default locations
 -----------------
-binaries: /opt/zookeeper  
-data:     /var/lib/zookeeper  
-logs:     /var/log/zookeeper  
-configs:  /etc/zookeeper, /etc/sysconfig/zookeeper  
+archives: /usr/share/java/zookeeper
+data:     /var/lib/zookeeper
+logs:     /var/log/zookeeper
+configs:  /etc/zookeeper, /etc/sysconfig/zookeeper

--- a/zookeeper.logrotate
+++ b/zookeeper.logrotate
@@ -1,11 +1,9 @@
 /var/log/zookeeper/*.log {
-       weekly
-       rotate 4
-       maxsize 100M
-       minsize 10M
-       copytruncate
-       delaycompress
-       compress
-       notifempty
-       missingok
+    weekly
+    rotate 4
+    maxsize 100M
+    minsize 10M
+    copytruncate
+    compress
+    missingok
 }

--- a/zookeeper.service
+++ b/zookeeper.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 User=zookeeper
-Group=zookeeper
 EnvironmentFile=/etc/sysconfig/zookeeper
+Environment=CLASSPATH=@CLASSPATH@
 ExecStart=/bin/java -cp $CLASSPATH $LOG4J $JVMFLAGS $ZOOMAIN $ZOOCFG
 
 [Install]

--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -1,76 +1,73 @@
 %define __jar_repack 0
-%define debug_package %{nil}
-%define name         zookeeper
-%define _prefix      /opt
-%define _conf_dir    %{_sysconfdir}/zookeeper
-%define _log_dir     %{_var}/log/zookeeper
-%define _data_dir    %{_sharedstatedir}/zookeeper
+#define debug_package %{nil}
+%define zk_prefix     %{_javadir}/zookeeper
+%define zk_confdir    %{_sysconfdir}/zookeeper
+%define zk_logdir     %{_var}/log/zookeeper
+%define zk_datadir    %{_sharedstatedir}/zookeeper
 
-Summary: ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
+Summary: High-performance coordination service for distributed applications
 Name: zookeeper
-Version: %{version}
-Release: %{build_number}
-License: Apache License, Version 2.0
+#Version: %{version}
+#Release: %{release}%{?dist}
+Version: 3.4.9
+Release: 1%{?dist}
+License: ASL 2.0 and BSD
 Group: Applications/Databases
-URL: http://zookeper.apache.org/
-Source0: zookeeper-%{version}.tar.gz
+URL: https://zookeeper.apache.org/
+Source0: https://www.apache.org/dyn/closer.cgi/zookeeper/zookeeper-%{version}/zookeeper-%{version}.tar.gz
 Source1: zookeeper.service
-Source2: zookeeper.logrotate
-Source3: zoo.cfg
-Source4: log4j.properties
-Source5: log4j-cli.properties
-Source6: zookeeper.sysconfig
-Source7: zkcli
-BuildRoot: %{_tmppath}/%{name}-%{version}-root
-Prefix: %{_prefix}
-Vendor: Apache Software Foundation
-Packager: Ivan Dyachkov <ivan.dyachkov@klarna.com>
-Provides: zookeeper
+Source2: zkcli
+Source3: zookeeper.logrotate
+Source4: zookeeper.sysconfig
+Source5: zoo.cfg
+Source6: log4j.properties
+Source7: log4j-cli.properties
+%{?systemd_requires}
 BuildRequires: systemd
-Requires(post): systemd
-Requires(preun): systemd
-Requires(postun): systemd
+BuildArch: noarch
 
 %description
-ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. All of these kinds of services are used in some form or another by distributed applications. Each time they are implemented there is a lot of work that goes into fixing the bugs and race conditions that are inevitable. Because of the difficulty of implementing these kinds of services, applications initially usually skimp on them ,which make them brittle in the presence of change and difficult to manage. Even when done correctly, different implementations of these services lead to management complexity when the applications are deployed.
+ZooKeeper is a high-performance coordination service for distributed
+applications. It exposes common services - such as naming, configuration
+management, synchronization, and group services - in a simple interface so
+you don't have to write them from scratch. You can use it off-the-shelf to
+implement consensus, group management, leader election, and presence
+protocols. And you can build on it for your own, specific needs.
 
 %prep
-%setup
+%setup -q
 
 %build
 
 %install
-mkdir -p $RPM_BUILD_ROOT%{_prefix}/zookeeper
-mkdir -p $RPM_BUILD_ROOT%{_log_dir}
-mkdir -p $RPM_BUILD_ROOT%{_data_dir}
-mkdir -p $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d
-mkdir -p $RPM_BUILD_ROOT%{_conf_dir}/
-install -p -D -m 644 zookeeper-%{version}.jar $RPM_BUILD_ROOT%{_prefix}/zookeeper/
-install -p -D -m 644 lib/*.jar $RPM_BUILD_ROOT%{_prefix}/zookeeper/
-install -p -D -m 755 %{S:1} $RPM_BUILD_ROOT%{_unitdir}/
-install -p -D -m 644 %{S:2} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/zookeeper
-install -p -D -m 644 %{S:3} $RPM_BUILD_ROOT%{_conf_dir}/
-install -p -D -m 644 %{S:4} $RPM_BUILD_ROOT%{_conf_dir}/
-install -p -D -m 644 %{S:5} $RPM_BUILD_ROOT%{_conf_dir}/
-install -p -D -m 644 %{S:6} $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/zookeeper
-install -p -D -m 755 %{S:7} $RPM_BUILD_ROOT/usr/local/bin/zkcli
-install -p -D -m 644 conf/configuration.xsl $RPM_BUILD_ROOT%{_conf_dir}/
-# stupid systemd fails to expand file paths in runtime
+# JARs
+mkdir -p $RPM_BUILD_ROOT%{zk_prefix}
+install -p -m 0644 zookeeper-%{version}.jar lib/*.jar \
+  $RPM_BUILD_ROOT%{zk_prefix}/
+# Service, systemd fails to expand file paths in runtime
+mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 CLASSPATH=
-for i in $RPM_BUILD_ROOT%{_prefix}/zookeeper/*.jar
-do
-  CLASSPATH="%{_prefix}/zookeeper/$(basename ${i}):${CLASSPATH}"
+for i in $RPM_BUILD_ROOT%{zk_prefix}/*.jar; do
+  CLASSPATH="%{zk_prefix}/$(basename ${i}):${CLASSPATH}"
 done
-echo "[Service]" > $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d/classpath.conf
-echo "Environment=CLASSPATH=${CLASSPATH}" >> $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d/classpath.conf
-
-%clean
-rm -rf $RPM_BUILD_ROOT
+sed -e "s|@CLASSPATH@|${CLASSPATH}|" %{S:1} > \
+  $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service
+# CLI
+install -p -D -m 0755 %{S:2} $RPM_BUILD_ROOT%{_bindir}/zkcli
+# Configuration
+install -p -D -m 0644 %{S:3} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/zookeeper
+install -p -D -m 0644 %{S:4} $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/zookeeper
+mkdir -p $RPM_BUILD_ROOT%{zk_confdir}/
+install -p -m 0644 %{S:5} %{S:6} %{S:7} conf/configuration.xsl \
+  $RPM_BUILD_ROOT%{zk_confdir}/
+# Empty directories
+mkdir -p $RPM_BUILD_ROOT%{zk_logdir}
+mkdir -p $RPM_BUILD_ROOT%{zk_datadir}
 
 %pre
 /usr/bin/getent group zookeeper >/dev/null || /usr/sbin/groupadd -r zookeeper
-if ! /usr/bin/getent passwd zookeeper >/dev/null ; then
-    /usr/sbin/useradd -r -g zookeeper -m -d %{_prefix}/zookeeper -s /bin/bash -c "Zookeeper" zookeeper
+if ! /usr/bin/getent passwd zookeeper >/dev/null; then
+  /usr/sbin/useradd -r -g zookeeper -M -N -d %{zk_prefix} -s /bin/bash -c "Zookeeper" zookeeper
 fi
 
 %post
@@ -80,22 +77,17 @@ fi
 %systemd_preun zookeeper.service
 
 %postun
-# When the last version of a package is erased, $1 is 0
-# Otherwise it's an upgrade and we need to restart the service
-if [ $1 -ge 1 ]; then
-    /usr/bin/systemctl restart zookeeper.service
-fi
-/usr/bin/systemctl daemon-reload >/dev/null 2>&1 || :
+%systemd_postun_with_restart zookeeper.service
 
 %files
-%defattr(-,root,root)
+%license LICENSE.txt
+%{zk_prefix}/
 %{_unitdir}/zookeeper.service
-%{_unitdir}/zookeeper.service.d/classpath.conf
-/usr/local/bin/zkcli
+%{_bindir}/zkcli
 %config(noreplace) %{_sysconfdir}/logrotate.d/zookeeper
 %config(noreplace) %{_sysconfdir}/sysconfig/zookeeper
-%config(noreplace) %{_conf_dir}/*
-%attr(-,zookeeper,zookeeper) %{_prefix}/zookeeper
-%attr(0755,zookeeper,zookeeper) %dir %{_log_dir}
-%attr(0700,zookeeper,zookeeper) %dir %{_data_dir}
+%dir %{zk_confdir}/
+%config(noreplace) %{zk_confdir}/*
+%attr(0755,zookeeper,zookeeper) %dir %{zk_logdir}/
+%attr(0700,zookeeper,zookeeper) %dir %{zk_datadir}/
 

--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -1,16 +1,16 @@
-%define __jar_repack 0
-#define debug_package %{nil}
-%define zk_prefix     %{_javadir}/zookeeper
-%define zk_confdir    %{_sysconfdir}/zookeeper
-%define zk_logdir     %{_var}/log/zookeeper
-%define zk_datadir    %{_sharedstatedir}/zookeeper
+%global __jar_repack 0
+%global zk_prefix  %{_javadir}/zookeeper
+%global zk_confdir %{_sysconfdir}/zookeeper
+%global zk_logdir  %{_var}/log/zookeeper
+%global zk_datadir %{_sharedstatedir}/zookeeper
+
+%{!?zk_version:%global zk_version 3.4.9}
+%{!?zk_release:%global zk_release 2}
 
 Summary: High-performance coordination service for distributed applications
 Name: zookeeper
-#Version: %{version}
-#Release: %{release}%{?dist}
-Version: 3.4.9
-Release: 1%{?dist}
+Version: %{zk_version}
+Release: %{zk_release}%{?dist}
 License: ASL 2.0 and BSD
 Group: Applications/Databases
 URL: https://zookeeper.apache.org/
@@ -25,6 +25,7 @@ Source7: log4j-cli.properties
 %{?systemd_requires}
 BuildRequires: systemd
 BuildArch: noarch
+Requires: java-headless
 
 %description
 ZooKeeper is a high-performance coordination service for distributed
@@ -90,4 +91,11 @@ fi
 %config(noreplace) %{zk_confdir}/*
 %attr(0755,zookeeper,zookeeper) %dir %{zk_logdir}/
 %attr(0700,zookeeper,zookeeper) %dir %{zk_datadir}/
+
+%changelog
+* Wed Oct 26 2016 Matthias Saou <matthias@saou.eu> 3.4.9-2
+- Add java-headless requirement.
+
+* Tue Oct 11 2016 Matthias Saou <matthias@saou.eu> 3.4.9-1
+- Simplify, fix and clean up the spec file and related files.
 


### PR DESCRIPTION
These are a lot of changes, so feel free to close/ignore and I won't be offended! :smile:

There are many minor things, so I'll just outline the major ones : 
 * It's now also possible to build from the spec file (using mock for instance).
 * The package is noarch, which is more correct and doesn't create any debuginfo by default.
 * The extra service.d file was merged into the main unit file.
 * The java-headless requirement was added, in order to pull in a JRE if none was present.

Let me know if there is anything you dislike or if you have any questions regarding some specific changes.