### PR TITLE
Changes from #3 and a few more improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY:	rpm clean
 
+NAME ?= zookeeper
 VERSION ?= 3.4.14
-BUILD_NUMBER ?= 1
+RELEASE ?= 1
 SOURCE = zookeeper-$(VERSION).tar.gz
 TOPDIR = /tmp/zookeeper-rpm
 PWD = $(shell pwd)
@@ -12,8 +13,9 @@ rpm: $(SOURCE)
 			--define "_sourcedir $(PWD)" \
 			--define "_rpmdir $(PWD)/RPMS" \
 			--define "_topdir $(TOPDIR)" \
-			--define "version $(VERSION)" \
-			--define "build_number $(BUILD_NUMBER)" \
+			--define "zk_name $(NAME)" \
+			--define "zk_version $(VERSION)" \
+			--define "zk_release $(RELEASE)" \
 			zookeeper.spec
 
 source: $(SOURCE)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ or use Docker
 
     docker build -t zookeeper-build . && docker run -ti -v $(pwd)/RPMS:/root/RPMS zookeeper-build
 
-Resulting RPM will be avaliable at $(shell pwd)/RPMS/x86_64
+Resulting RPM will be avaliable at $(shell pwd)/RPMS/noarch/
 
 Installing and operating
 ------------------------
@@ -23,11 +23,11 @@ Installing and operating
     sudo systemctl start zookeeper
     sudo systemctl enable zookeeper
 
-Zookeeper shell is available via /usr/local/bin/zkcli or just zkcli since /usr/local/bin is usually in the $PATH.
+Zookeeper shell is available via zkcli.
 
 Default locations
 -----------------
-binaries: /opt/zookeeper  
-data:     /var/lib/zookeeper  
-logs:     /var/log/zookeeper  
-configs:  /etc/zookeeper, /etc/sysconfig/zookeeper  
+archives: /usr/share/java/zookeeper
+data:     /var/lib/zookeeper
+logs:     /var/log/zookeeper
+configs:  /etc/zookeeper, /etc/sysconfig/zookeeper

--- a/zoo.cfg
+++ b/zoo.cfg
@@ -7,8 +7,6 @@ initLimit=10
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-# do not use /tmp for storage, /tmp here is just
-# example sakes.
 dataDir=/var/lib/zookeeper
 # the port at which the clients will connect
 clientPort=2181

--- a/zookeeper.logrotate
+++ b/zookeeper.logrotate
@@ -1,11 +1,9 @@
 /var/log/zookeeper/*.log {
-       weekly
-       rotate 4
-       maxsize 100M
-       minsize 10M
-       copytruncate
-       delaycompress
-       compress
-       notifempty
-       missingok
+    weekly
+    rotate 4
+    maxsize 100M
+    minsize 10M
+    copytruncate
+    compress
+    missingok
 }

--- a/zookeeper.service
+++ b/zookeeper.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 User=zookeeper
-Group=zookeeper
 EnvironmentFile=/etc/sysconfig/zookeeper
+Environment=CLASSPATH=.:/usr/share/java/zookeeper/*
 ExecStart=/bin/java -cp $CLASSPATH $LOG4J $JVMFLAGS $ZOOMAIN $ZOOCFG
 SuccessExitStatus=143
 

--- a/zookeeper.spec
+++ b/zookeeper.spec
@@ -1,71 +1,78 @@
-%define __jar_repack 0
-%define debug_package %{nil}
-%define name         zookeeper
-%define _prefix      /opt
-%define _conf_dir    %{_sysconfdir}/%{name}
-%define _log_dir     %{_var}/log/%{name}
-%define _data_dir    %{_sharedstatedir}/%{name}
+%global __jar_repack 0
+%global zk_prefix  %{_javadir}/zookeeper
+%global zk_confdir %{_sysconfdir}/zookeeper
+%global zk_logdir  %{_var}/log/zookeeper
+%global zk_datadir %{_sharedstatedir}/zookeeper
 
-Summary: ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services.
-Name: zookeeper
-Version: %{version}
-Release: %{build_number}
-License: Apache License, Version 2.0
+%{!?zk_name:%global zk_name zookeeper}
+%{!?zk_version:%global zk_version 3.4.14}
+%{!?zk_release:%global zk_release 1}
+
+Summary: High-performance coordination service for distributed applications
+Name: %{zk_name}
+Version: %{zk_version}
+Release: %{zk_release}%{?dist}
+License: ASL 2.0 and BSD
 Group: Applications/Databases
-URL: http://zookeper.apache.org/
-Source0: %{name}-%{version}.tar.gz
-Source1: %{name}.service
-Source2: %{name}.logrotate
+URL: https://zookeeper.apache.org/
+Source0: https://www-eu.apache.org/dist/zookeeper/zookeeper-%{version}/zookeeper-%{version}.tar.gz
+Source1: zookeeper.service
+Source2: zookeeper.logrotate
 Source3: zoo.cfg
-Source4: %{name}.log4j.properties
-Source5: %{name}.log4j-cli.properties
-Source6: %{name}.sysconfig
+Source4: zookeeper.log4j.properties
+Source5: zookeeper.log4j-cli.properties
+Source6: zookeeper.sysconfig
 Source7: zkcli
-BuildRoot: %{_tmppath}/%{name}-%{version}-root
-Prefix: %{_prefix}
-Vendor: Apache Software Foundation
-Packager: Ivan Dyachkov <ivan.dyachkov@klarna.com>
-Provides: %{name}
-BuildRequires: systemd
-Requires(post): systemd
-Requires(preun): systemd
-Requires(postun): systemd
+%{?systemd_requires}
+BuildArch: noarch
+Requires: java-headless
 
 %description
-ZooKeeper is a centralized service for maintaining configuration information, naming, providing distributed synchronization, and providing group services. All of these kinds of services are used in some form or another by distributed applications. Each time they are implemented there is a lot of work that goes into fixing the bugs and race conditions that are inevitable. Because of the difficulty of implementing these kinds of services, applications initially usually skimp on them ,which make them brittle in the presence of change and difficult to manage. Even when done correctly, different implementations of these services lead to management complexity when the applications are deployed.
+ZooKeeper is a high-performance coordination service for distributed
+applications. It exposes common services - such as naming, configuration
+management, synchronization, and group services - in a simple interface so
+you don't have to write them from scratch. You can use it off-the-shelf to
+implement consensus, group management, leader election, and presence
+protocols. And you can build on it for your own, specific needs.
+
+%package -n nagios-plugins-zookeeper
+Group: Applications/System
+Summary: Provides check_zookeeper support for Nagios
+Requires: nagios-plugins
+
+%description -n nagios-plugins-zookeeper
+Provides check_zookeeper support for Nagios.
 
 %prep
-%setup -q
+%setup -q -n zookeeper-%{version}
 
 %build
 
 %install
-mkdir -p $RPM_BUILD_ROOT%{_prefix}/zookeeper
-mkdir -p $RPM_BUILD_ROOT%{_log_dir}
-mkdir -p $RPM_BUILD_ROOT%{_data_dir}
-mkdir -p $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d
-mkdir -p $RPM_BUILD_ROOT%{_conf_dir}/
-install -p -D -m 644 zookeeper-%{version}.jar $RPM_BUILD_ROOT%{_prefix}/zookeeper/
-install -p -D -m 644 lib/*.jar $RPM_BUILD_ROOT%{_prefix}/zookeeper/
-install -p -D -m 755 %{S:1} $RPM_BUILD_ROOT%{_unitdir}/
-install -p -D -m 644 %{S:2} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/zookeeper
-install -p -D -m 644 %{S:3} $RPM_BUILD_ROOT%{_conf_dir}/
-install -p -D -m 644 %{S:4} $RPM_BUILD_ROOT%{_conf_dir}/log4j.properties
-install -p -D -m 644 %{S:5} $RPM_BUILD_ROOT%{_conf_dir}/log4j-cli.properties
-install -p -D -m 644 %{S:6} $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/zookeeper
-install -p -D -m 755 %{S:7} $RPM_BUILD_ROOT%{_bindir}/zkcli
-install -p -D -m 644 conf/configuration.xsl $RPM_BUILD_ROOT%{_conf_dir}/
-# stupid systemd fails to expand file paths in runtime
-CLASSPATH=
-for i in $RPM_BUILD_ROOT%{_prefix}/zookeeper/*.jar
-do
-  CLASSPATH="%{_prefix}/zookeeper/$(basename ${i}):${CLASSPATH}"
-done
-echo "[Service]" > $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d/classpath.conf
-echo "Environment=CLASSPATH=${CLASSPATH}" >> $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service.d/classpath.conf
-
-%clean
-rm -rf $RPM_BUILD_ROOT
+# JARs
+mkdir -p $RPM_BUILD_ROOT%{zk_prefix}
+install -p -m 0644 zookeeper-%{version}.jar lib/*.jar \
+  $RPM_BUILD_ROOT%{zk_prefix}/
+# Service, systemd fails to expand file paths in runtime
+install -p -D -m 0644 %{S:1} $RPM_BUILD_ROOT%{_unitdir}/zookeeper.service
+mkdir -p $RPM_BUILD_ROOT%{_unitdir}
+# Configuration
+install -p -D -m 0644 %{S:2} $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/zookeeper
+install -p -D -m 0644 %{S:3} $RPM_BUILD_ROOT%{zk_confdir}/zoo.cfg
+install -p -D -m 0644 %{S:4} $RPM_BUILD_ROOT%{zk_confdir}/log4j.properties
+install -p -D -m 0644 %{S:5} $RPM_BUILD_ROOT%{zk_confdir}/log4j-cli.properties
+install -p -D -m 0644 %{S:6} $RPM_BUILD_ROOT%{_sysconfdir}/sysconfig/zookeeper
+# CLI
+install -p -D -m 0755 %{S:7} $RPM_BUILD_ROOT%{_bindir}/zkcli
+# Empty directories
+mkdir -p $RPM_BUILD_ROOT%{zk_logdir}
+mkdir -p $RPM_BUILD_ROOT%{zk_datadir}
+# Nagios plugin, enforce python2 for RHEL8
+install -D -p -m 0755 \
+  zookeeper-contrib/zookeeper-contrib-monitoring/check_zookeeper.py \
+  $RPM_BUILD_ROOT%{_libdir}/nagios/plugins/check_zookeeper
+sed -i -e 's/python$/python2/g' \
+  $RPM_BUILD_ROOT%{_libdir}/nagios/plugins/check_zookeeper
 
 %pre
 /usr/bin/getent group zookeeper >/dev/null || /usr/sbin/groupadd -r zookeeper
@@ -80,22 +87,20 @@ fi
 %systemd_preun zookeeper.service
 
 %postun
-# When the last version of a package is erased, $1 is 0
-# Otherwise it's an upgrade and we need to restart the service
-if [ $1 -ge 1 ]; then
-    /usr/bin/systemctl restart zookeeper.service
-fi
-/usr/bin/systemctl daemon-reload >/dev/null 2>&1 || :
+%systemd_postun_with_restart zookeeper.service
 
 %files
-%defattr(-,root,root)
+%license LICENSE.txt
+%{zk_prefix}/
 %{_unitdir}/zookeeper.service
-%{_unitdir}/zookeeper.service.d/classpath.conf
 %{_bindir}/zkcli
 %config(noreplace) %{_sysconfdir}/logrotate.d/zookeeper
 %config(noreplace) %{_sysconfdir}/sysconfig/zookeeper
-%config(noreplace) %{_conf_dir}/*
-%attr(-,zookeeper,zookeeper) %{_prefix}/zookeeper
-%attr(0755,zookeeper,zookeeper) %dir %{_log_dir}
-%attr(0700,zookeeper,zookeeper) %dir %{_data_dir}
+%dir %{zk_confdir}/
+%config(noreplace) %{zk_confdir}/*
+%attr(0755,zookeeper,zookeeper) %dir %{zk_logdir}/
+%attr(0700,zookeeper,zookeeper) %dir %{zk_datadir}/
+
+%files -n nagios-plugins-zookeeper
+%{_libdir}/nagios/plugins/check_zookeeper
 


### PR DESCRIPTION
* Allow package name override, for multiple versions in a single repository
* Hardcode working CLASSPATH in the systemd service file

See #3 (which can probably be closed) for the initial discussion. I've added the ability to use something like `make NAME=zookeeper34` to override the package name, allowing it to co-exist with others inside a single repository. It doesn't allow to be parallel installed, but it can be useful nevertheless (with 3.5.x, for instance). For this to work, I had to revert a lot of the `%{name}` usage introduced recently... it typically seems like a good idea to use `%{name}`, but IMHO it usually isn't: It theoretically increases spec file "reusability" for other projects, but little more, and gets in the way once you want to rename a package like in this case.

I have this modified package running on some servers just fine, but feel free to test in depth, double check, adapt as needed and ask about anything that could be unclear.

There have been no changes to the `noreplace` config files, so updating should always be smooth. This is also the reason why the `CLASSPATH` is set in the systemd service file and not the sysconfig file.